### PR TITLE
Add fail safe  conditions

### DIFF
--- a/blueprints/automation/danielhall/bambu_print_notify.yaml
+++ b/blueprints/automation/danielhall/bambu_print_notify.yaml
@@ -793,6 +793,13 @@ action:
   - if:
       - condition: template
         value_template: "{{ trigger.id == 'progress_threshold' }}"
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: !input print_status_sensor
+        state:
+          - finish
+          - failed
     then:
       - wait_for_trigger:
           - platform: state


### PR DESCRIPTION
There is a delay in the previous steps which can cause the print status to already be in the finished state. This causes the trigger to wait for the timeout. Adding the finish and fails print status as a negative condition makes sure the a step will not wait for a status that cannot be reached.

Fixes #7 .